### PR TITLE
only adjust runtime flag's value if it is actually passed to script

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -35,7 +35,7 @@ const run = async (options) => {
   const deviceType = 'jetson-tx2'
   const stat = await statAsync(options.file)
 
-  if (!path.isAbsolute(options.output)) {
+  if (options.output && !path.isAbsolute(options.output)) {
     options.output = path.join(process.cwd(), options.output)
   }
 


### PR DESCRIPTION
If the `--output <OUTPUT>` flag is not passed, that previous version freaks out working on an undefined value of that flag.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>