### PR TITLE
package.json: Update ext2fs tpo version 1.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/resin-os/resin-jetson-flash#readme",
   "dependencies": {
-    "ext2fs": "^1.0.7",
+    "ext2fs": "^1.0.13",
     "file-disk": "^4.1.3",
     "fs-extra": "^6.0.1",
     "hasha": "^3.0.0",


### PR DESCRIPTION
This fixes reading large files (over 4 GiB) from an ext filesystem

Signed-off-by: Florin Sarbu <florin@resin.io>